### PR TITLE
Update pwd.yml to support Coolify

### DIFF
--- a/pwd.yml
+++ b/pwd.yml
@@ -114,7 +114,7 @@ services:
       - nginx-entrypoint.sh
     environment:
       BACKEND: backend:8000
-      FRAPPE_SITE_NAME_HEADER: frontend
+      FRAPPE_SITE_NAME_HEADER: $$host
       SOCKETIO: websocket:9000
       UPSTREAM_REAL_IP_ADDRESS: 127.0.0.1
       UPSTREAM_REAL_IP_HEADER: X-Forwarded-For
@@ -124,8 +124,6 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs
-    ports:
-      - "8080:8080"
 
   queue-long:
     image: frappe/erpnext:v15.78.0


### PR DESCRIPTION
- Removed host port mapping (8080:8080) from frontend to avoid conflicts with Coolify’s proxy
- Changed FRAPPE_SITE_NAME_HEADER from hardcoded "frontend" to "$$host" for proper host header routing
- Kept service definitions aligned with upstream compose.yaml for proxy-friendly setup
- This allows Coolify to handle domain routing on ports 80/443 instead of binding container directly

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
